### PR TITLE
Be less restrictive about dependencies versions and solve elixir 1.4 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,10 +9,10 @@ defmodule BigQuery.Mixfile do
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      docs: [extras: ["README.md"]],
      description: "A Google BigQuery API client.",
-     package: package]
+     package: package()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Some minor changes to `mix.exs` that I found necessary.