### PR TITLE
Make it possible to load the BigQuery configuration from a string instead of a file

### DIFF
--- a/lib/big_query/access_token.ex
+++ b/lib/big_query/access_token.ex
@@ -5,13 +5,9 @@ defmodule BigQuery.AccessToken do
   # Based on https://gist.github.com/plamb/8c8f39cfba9e69cb034a/871a9b8128117518cdfbbf46b4cd405b5353f6c6
   @spec get_token :: {:ok, String.t} | {:error, String.t}
   def get_token() do
-    key_file = Application.get_env(:big_query, :bigquery_private_key_path)
-    key_json = File.read!(key_file)
-    key_map = JOSE.decode(key_json)
-
-    jwk = JOSE.JWK.from_pem(key_map["private_key"])
-
+    %{"private_key" => private_key, "client_email" => client_email} = key_data()
     jws = %{"alg" => "RS256"}
+    jwk = JOSE.JWK.from_pem(private_key)
 
     header = %{
       "alg" => "RS256",
@@ -23,7 +19,7 @@ defmodule BigQuery.AccessToken do
 
     bigquery_scope = Application.get_env(:big_query, :bigquery_scope, "")
     claims = %{
-      "iss" => key_map["client_email"],
+      "iss" => client_email,
       "scope" => "#{bigquery_scope} https://www.googleapis.com/auth/bigquery.readonly https://www.googleapis.com/auth/bigquery.insertdata https://www.googleapis.com/auth/bigquery",
       "aud" => "https://www.googleapis.com/oauth2/v3/token",
       "exp" => exp,
@@ -45,5 +41,21 @@ defmodule BigQuery.AccessToken do
       {:error, error} ->
         {:error, HTTPoison.Error.message(error)}
     end
+  end
+
+  defp key_data do
+    key_file = Application.get_env(:big_query, :bigquery_private_key_path)
+
+    data = if File.regular?(key_file) do
+      File.read!(key_file)
+    else
+      Application.get_env(:big_query, :bigquery_private_key_data)
+    end
+
+    if data == nil do
+      raise ArgumentError, message: "You must set big_query.bigquery_private_key_path or big_quer.bigquery_private_key_data"
+    end
+
+    JOSE.decode(data)
   end
 end


### PR DESCRIPTION
I use this as below (`/keys` is in my `.gitignore`)
##### config/dev.exs
`config :big_query, bigquery_private_key_path: "keys/bigquery.json"`

##### config/prod.exs
`config :big_query, bigquery_private_key_data: System.get_env("BIG_QUERY_PRIVATE_KEY_DATA")`
